### PR TITLE
[FIX] 상품 검색 시 ProductStatus를 다시 대문자로 주도록 변경

### DIFF
--- a/src/api/product.js
+++ b/src/api/product.js
@@ -11,7 +11,7 @@ export const searchProducts = (params = {}) => {
       minPrice: params.minPrice || null,
       maxPrice: params.maxPrice || null,
       sellerCode: params.sellerCode || null,
-      productStatus: params.productStatus.toLowerCase() || null,
+      productStatus: params.productStatus.toUpperCase() || null,
       sortBy: params.sortBy || 'createdAt',
       sortDirection: params.sortDirection || 'desc',
       page: params.page || 1,


### PR DESCRIPTION
## 📌 PR 요약
### 1. 상품 검색 시 productStatus를 다시 대문자로 주도록 변경

## 🧩 변경 사항
- [ ] 새로운 기능 추가
- [x] 버그 수정
- [ ] 리팩토링
- [ ] 문서 수정

## 💡 참고 사항
### 1. 상품 검색 시 productStatus를 다시 대문자로 주도록 변경하였습니다.